### PR TITLE
Add Avatar component and corresponding element to storybook - closes #5

### DIFF
--- a/src/Elements/Avatar.js
+++ b/src/Elements/Avatar.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { css, withStyles } from "../withStyles";
+
+const Avatar = ({
+  styles,
+  image = null,
+  size = "small",
+  children,
+  ...props
+}) => (
+  <span {...css(styles.avatar, styles[size])} {...props}>
+    {image && <img {...css(styles.image)} src={image} />}
+    {children}
+  </span>
+);
+
+export default withStyles(({ theme, text }) => {
+  return {
+    avatar: {
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      borderRadius: "50%",
+
+      /* could be made dynamic */
+      backgroundColor: theme.primary.backgroundColor,
+      color: theme.primary.color
+    },
+
+    /* Image */
+    image: {
+      display: "block",
+      borderRadius: "50%",
+      height: "100%",
+      width: "100%",
+      objectFit: "cover",
+      userDrag: "none"
+    },
+
+    /* Size */
+    small: { width: "3.2rem", height: "3.2rem" },
+    medium: { width: "4.8rem", height: "4.8rem" },
+    large: { width: "6.4rem", height: "6.4rem" }
+  };
+})(Avatar);

--- a/src/Elements/Avatar.js
+++ b/src/Elements/Avatar.js
@@ -14,7 +14,7 @@ const Avatar = ({
   </span>
 );
 
-export default withStyles(({ theme, text }) => {
+export default withStyles(({ theme }) => {
   return {
     avatar: {
       display: "flex",

--- a/src/stories/Elements/Avatar.js
+++ b/src/stories/Elements/Avatar.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+import { storiesOf } from "@storybook/react";
+
+import Avatar from "../../Elements/Avatar";
+
+storiesOf("Avatar", module)
+  .add("Default (Small)", () => <Avatar image="https://placehold.it/64x128" />)
+  .add("Medium", () => (
+    <Avatar size="medium" image="https://placehold.it/64x128" />
+  ))
+  .add("Large", () => (
+    <Avatar size="large" image="https://placehold.it/64x128" />
+  ))
+  .add("Medium - Text passed", () => <Avatar size="medium">JD</Avatar>)
+  .add("Default (Small) - No image passed", () => <Avatar />);

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -10,6 +10,7 @@ import Button from "../Elements/Button";
 import Input from "../Elements/Input";
 
 import Heading from "./Elements/Heading";
+import Avatar from "./Elements/Avatar";
 
 storiesOf("Button", module)
   .add("Default", () => <Button>Default button</Button>)


### PR DESCRIPTION
Created the Avatar component

By default the size is set to `small` use `<Avatar size="medium/small" />` to override.

Also takes an `image="url"` which is optional, but would probably be used in most scenarios.

See storybook -> Avatar to view.

In summary:

```
<Avatar image="someUrl" size="medium">JD</Avatar/>
```

--

Hardcoded sizes for now while waiting for global theme changes