### PR TITLE
resolved whole theme being added to heading rather than only color - closes chas-academy/Cobalt-client#2

### DIFF
--- a/src/Elements/Heading.js
+++ b/src/Elements/Heading.js
@@ -11,8 +11,14 @@ export default withStyles(({ theme }) => {
     heading: {},
 
     /* Color */
-    default: theme.default,
-    primary: theme.primary,
-    secondary: theme.secondary
+    default: {
+      color: theme.default.color
+    },
+    primary: {
+      color: theme.primary.color
+    },
+    secondary: {
+      color: theme.secondary.color
+    }
   };
 })(Heading);


### PR DESCRIPTION
* Fixed issue where headings got all styling from themes rather than only the color property.