### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
-FROM node:9.2.1
-CMD yarn install && yarn start
+FROM mhart/alpine-node:latest
+
+ADD yarn.lock /yarn.lock
+ADD package.json /package.json
+
+ENV NODE_PATH=/node_modules
+ENV PATH=$PATH:/node_modules/.bin
+
+RUN yarn
+
+WORKDIR /app
+ADD . /app
+
 EXPOSE 7771
+
+CMD ["yarn", "start"]

--- a/src/Elements/FlexContainer.js
+++ b/src/Elements/FlexContainer.js
@@ -1,6 +1,0 @@
-import React from "react";
-import { css, withStyles } from "../withStyles";
-
-const FlexContainer = props => <div {...props} />;
-
-export default FlexContainer;

--- a/src/Elements/FlexContainer.js
+++ b/src/Elements/FlexContainer.js
@@ -1,0 +1,6 @@
+import React from "react";
+import { css, withStyles } from "../withStyles";
+
+const FlexContainer = props => <div {...props} />;
+
+export default FlexContainer;


### PR DESCRIPTION
Updating Dockerfile for client. Necessary to prevent conflicts with node_modules in yarn and docker.

Change from node to alpine-node. Lighter.