### PR TITLE
refactor icon, add styling to inputWithIcon closes #66

### DIFF
--- a/src/Elements/Icon.js
+++ b/src/Elements/Icon.js
@@ -1,38 +1,40 @@
 import React from "react";
 import { css, withStyles } from "../withStyles";
 
-const Icon = ({ appearance = "default", size = "small", styles, ...props }) => (
-  <span {...css(styles.icon, styles[size], styles[appearance])} {...props} />
+const Icon = ({
+  icon = null,
+  fillColor = "white",
+  size = "small",
+  styles,
+  ...props
+}) => (
+  <span {...css(styles.icon, styles[size], styles[fillColor])} {...props}>
+    <i className={icon} />
+  </span>
 );
 
-export default withStyles(({ themes, text, colors }) => {
+export default withStyles(({ colors, text }) => {
   return {
     icon: {
       padding: "14px"
     },
-    /* TODO: Refactor to accept icon-name, height, width, fillColor, use svg */
-    /* Color */
-
-    /* Color */
-    default: {
-      color: themes.default.color
-    },
-    primary: {
-      color: themes.primary.color
-    },
-    secondary: {
-      color: themes.secondary.color
-    },
-    danger: {
-      color: colors.danger
-    },
-    dawn: {
-      color: colors.dawn
-    },
+    /** TODO: change from fontawesome to svg? */
 
     /* Size */
+    xs: text.xs,
     small: text.small,
     medium: text.medium,
-    large: text.large
+    large: text.large,
+    /* Color */
+    primary: { color: colors.primary },
+    secondary: { color: colors.secondary },
+    danger: { color: colors.danger },
+    dawn: { color: colors.dawn },
+    nightsky: { color: colors.nightsky },
+    carbon: { color: colors.carbon },
+    darkMetal: { color: colors.darkMetal },
+    aluminum: { color: colors.aluminum },
+    sand: { color: colors.sand },
+    white: { color: "#FFF" }
   };
 })(Icon);

--- a/src/Elements/InputWithIcon.js
+++ b/src/Elements/InputWithIcon.js
@@ -6,34 +6,48 @@ import Input from "./Input";
 const InputWithIcon = ({
   appearance = "default",
   icon = null,
-  iconAppearance = "default",
+  iconFillColor = "default",
   iconPosition = "left",
-  iconColor = "default",
+  iconBackground = null,
   placeholder = null,
   styles,
   ...props
 }) => (
-  <div {...css(styles.inputDiv)} {...props}>
-    {iconPosition === "left" ? (
-      <Icon appearance={iconAppearance}>{icon}</Icon>
-    ) : (
-      ""
-    )}
+  <div {...css(styles.inputWithIcon, styles[iconPosition])} {...props}>
+    <div {...css(styles[iconBackground], styles.flex)}>
+      <Icon fillColor={iconFillColor} icon={icon} />
+    </div>
     <Input appearance={appearance} placeholder={placeholder} />
-    {iconPosition === "right" ? (
-      <Icon appearance={iconAppearance}>{icon}</Icon>
-    ) : (
-      ""
-    )}
   </div>
 );
 
-export default withStyles(({ themes }) => {
+export default withStyles(({ themes, colors }) => {
   return {
-    inputWithIcon: {},
-    inputDiv: {
+    inputWithIcon: {
       display: "flex",
-      width: "100%"
-    }
+      width: "100%",
+      alignItems: "center"
+    },
+    left: {
+      ":nth-child(1n) input": {
+        marginLeft: "0px"
+      }
+    },
+    right: {
+      flexDirection: "row-reverse",
+      marginRight: "0px"
+    },
+    flex: {
+      display: "flex"
+    },
+    primary: { backgroundColor: colors.primary },
+    secondary: { backgroundColor: colors.secondary },
+    danger: { backgroundColor: colors.danger },
+    dawn: { backgroundColor: colors.dawn },
+    nightsky: { backgroundColor: colors.nightsky },
+    carbon: { backgroundColor: colors.carbon },
+    darkMetal: { backgroundColor: colors.darkMetal },
+    aluminum: { backgroundColor: colors.aluminum },
+    sand: { backgroundColor: colors.sand }
   };
 })(InputWithIcon);

--- a/src/stories/Elements/Icon.js
+++ b/src/stories/Elements/Icon.js
@@ -7,18 +7,15 @@ import { linkTo } from "@storybook/addon-links";
 import Icon from "../../Elements/Icon";
 
 storiesOf("Icon", module)
-  .add("Default", () => (
-    <Icon>
-      <i class="fab fa-accessible-icon" />
-    </Icon>
+  .add("xs", () => (
+    <Icon icon="fab fa-accessible-icon" size="xs" fillColor="primary" />
   ))
-  .add("Medium", () => (
-    <Icon size="medium">
-      <i class="fab fa-accessible-icon" />
-    </Icon>
+  .add("small", () => (
+    <Icon icon="fab fa-accessible-icon" size="small" fillColor="secondary" />
   ))
-  .add("Large", () => (
-    <Icon size="large">
-      <i class="fab fa-accessible-icon" />
-    </Icon>
+  .add("medium", () => (
+    <Icon icon="fab fa-accessible-icon" size="medium" fillColor="nightsky" />
+  ))
+  .add("large", () => (
+    <Icon icon="fab fa-accessible-icon" size="large" fillColor="danger" />
   ));

--- a/src/stories/Elements/InputWithIcon.js
+++ b/src/stories/Elements/InputWithIcon.js
@@ -3,39 +3,43 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { linkTo } from "@storybook/addon-links";
-
 import InputWithIcon from "../../Elements/InputWithIcon";
 
 storiesOf("Input with icon", module)
   .add("Default (Left side)", () => (
     <InputWithIcon
-      icon={<i class="fas fa-users" />}
+      icon="fas fa-users"
+      iconFillColor="primary"
+      iconBackground="carbon"
       type="text"
       placeholder="Default (Left side)"
     />
   ))
   .add("Right side", () => (
     <InputWithIcon
-      icon={<i class="fas fa-users" />}
+      icon="fas fa-users"
       iconPosition="right"
+      iconBackground="nightsky"
       type="text"
       placeholder="Right side"
     />
   ))
   .add("Primay color", () => (
     <InputWithIcon
-      icon={<i class="fas fa-users" />}
+      icon="fas fa-users"
       appearance="primary"
       iconAppearance="primary"
+      iconBackground="nightsky"
       type="text"
       placeholder="Primary color"
     />
   ))
   .add("Secondary color", () => (
     <InputWithIcon
-      icon={<i class="fas fa-users" />}
+      icon="fas fa-users"
       appearance="secondary"
       iconAppearance="secondary"
+      iconBackground="sand"
       type="text"
       placeholder="Secondary color"
     />


### PR DESCRIPTION
Icon:
* Now accepts prop `icon="fa fas-icon`
* Now accepts prop `fillColor="carbon/sand/primary/etc."

InputWithIcon:
* Now accepts prop icon as shown above `icon="fa fas-icon`
* Now accepts prop `iconFillColor="carbon/sand/primary/etc."
* Now accepts prop iconBackground (this is by default set to null) `iconBackground="carbon/sand/primary/etc."`