### PR TITLE
Adds Socket IO for client side and a basic dummy route (with HOC) closes #73

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-with-styles-interface-aphrodite": "^5.0.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
+    "socket.io-client": "^2.1.0",
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {

--- a/src/Containers/App.js
+++ b/src/Containers/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Switch, Route } from "react-router-dom";
 
 import NotFound from "../Views/NotFound";
+import SocketClient from "../Views/Client";
 
 class App extends React.Component {
   render() {
@@ -10,6 +11,7 @@ class App extends React.Component {
         <main>
           <Switch>
             <Route exact path="/" />
+            <Route path="/:sessionId" component={SocketClient} />
             <Route path="*" component={NotFound} />
           </Switch>
         </main>

--- a/src/Views/Client.js
+++ b/src/Views/Client.js
@@ -1,0 +1,56 @@
+import React from "react";
+
+import io from "socket.io-client";
+
+const withSocket = WrappedComponent => {
+  return class extends React.Component {
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        data: {}
+      };
+
+      const {
+        match: {
+          params: { sessionId }
+        }
+      } = this.props;
+
+      this.sessionId = sessionId;
+      this.socket = io(`${process.env.REACT_APP_API_BASE_URL}`);
+    }
+
+    componentDidMount() {
+      this.socket.on("connect", () => {
+        this.socket.emit("session", this.sessionId);
+      });
+
+      this.listenForEvents();
+    }
+
+    listenForEvents() {
+      this.socket.on("message", data => {
+        console.log(data);
+        this.setState({
+          data: data
+        });
+      });
+    }
+
+    render() {
+      return <WrappedComponent data={this.state.data} {...this.props} />;
+    }
+  };
+};
+
+const Client = ({ data }) => {
+  return (
+    <React.Fragment>
+      <h1>Client View</h1>
+      <p>{JSON.stringify(data)}</p>
+    </React.Fragment>
+  );
+};
+
+export default withSocket(Client);


### PR DESCRIPTION
Added a route for joining sessions and a corresponding Client-component.

--

We should discuss how we should structure these views, but for now I just put everything inside of `Client.js`

I also created a simple HOC which we could (should) extend to handle most (if not all) the socket action