### PR TITLE
add REACT_APP_CLIENT_BASE_URL to .env.dist

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,4 @@
 REACT_APP_SITE_NAME=React App Boilerplate
 
 REACT_APP_API_BASE_URL=http://localhost:7770
+REACT_APP_CLIENT_BASE_URL=http://localhost:7771


### PR DESCRIPTION
This should fix process.env errors in deployed version