### PR TITLE
Fixes PrivateRoutes redirecting to Dashboard

### DIFF
--- a/src/Components/PrivateRoute.js
+++ b/src/Components/PrivateRoute.js
@@ -1,8 +1,30 @@
 import React from "react";
+import { connect } from "react-redux";
 import { Route, Redirect } from "react-router-dom";
 
-const PrivateRoute = ({ component: Component, authenticated, ...rest }) => {
-  return (
+import FlexContainer from "../Containers/FlexContainer";
+import Loader from "../Elements/Loader";
+
+const PrivateRoute = ({
+  component: Component,
+  authenticated,
+  isFetching,
+  ...rest
+}) => {
+  return isFetching ? (
+    <FlexContainer
+      align="center"
+      justify="center"
+      direction="column"
+      fullWidth="1"
+      style={{
+        height: "100vh"
+      }}
+    >
+      <p>Checking your credentials...</p>
+      <Loader fillColor="nightsky" size="large" />
+    </FlexContainer>
+  ) : (
     <Route
       {...rest}
       render={props =>
@@ -18,4 +40,9 @@ const PrivateRoute = ({ component: Component, authenticated, ...rest }) => {
   );
 };
 
-export default PrivateRoute;
+const mapStateToProps = state => ({
+  authenticated: state.auth.isAuthenticated,
+  isFetching: state.auth.isFetching
+});
+
+export default connect(mapStateToProps)(PrivateRoute);

--- a/src/Containers/App.js
+++ b/src/Containers/App.js
@@ -135,21 +135,12 @@ class App extends React.Component {
             <Route exact path="/contact" component={this.Contact} />
 
             <Route path="/session/:sessionId" component={Client} />
+            <PrivateRoute path="/summary/:sessionId" component={Summary} />
             <PrivateRoute
-              authenticated={isAuthenticated}
-              path="/summary/:sessionId"
-              component={Summary}
-            />
-            <PrivateRoute
-              authenticated={isAuthenticated}
               path="/host/:sessionId"
               component={LiveSessionHostWithSocket}
             />
-            <PrivateRoute
-              authenticated={isAuthenticated}
-              path="/dashboard"
-              component={Dashboard}
-            />
+            <PrivateRoute path="/dashboard" component={Dashboard} />
             <Route
               path="/pricing"
               render={routeProps => (
@@ -160,8 +151,6 @@ class App extends React.Component {
               )}
             />
             <Route path="/qr/:sessionId" component={QrCodeWindow} />
-            <Route path="/lobby" component={this.Lobby} />
-            <Route path="/dashboard" component={this.Dashboard} />
             <Route path="/scanner" component={Qrscanner} />
             <Route path="/developers" component={DevelopersPageWithPublic} />
             <Route path="/pricing" component={this.PricingArea} />


### PR DESCRIPTION
- Connected the PrivateRoute to redux so we don't need to pass `isAuthenticated` to every route
- added a loader which solves the previous problem where one was redirected to `Login` when `verifyAuth` was fetching leading to an inevitable redirect to `Dashboard`

closes #281 